### PR TITLE
Prevent movement on touchmove for locked sliders 

### DIFF
--- a/_src/jquery.iosslider.js
+++ b/_src/jquery.iosslider.js
@@ -1630,7 +1630,9 @@
 					var touchMoveEvent = isTouch ? 'touchmove.iosSliderEvent' : 'mousemove.iosSliderEvent';
 					
 					$(touchSelectionMove).bind(touchMoveEvent, function(e) {
-						
+
+						if(touchLocks[sliderNumber] || shortContent) return true;
+
 						if((!isIe7) && (!isIe8)) {
 							var e = e.originalEvent;
 						}


### PR DESCRIPTION
As this happens for the touchstart event (see line 1542), the lock must also be checked for the touchmove event - otherwise it does not have any effect for touch-aware devices.
