### PR TITLE
Fix for issue #178 and data cleanup

### DIFF
--- a/_src/jquery.iosslider.js
+++ b/_src/jquery.iosslider.js
@@ -2230,6 +2230,7 @@
 		    	$(window).unbind('.iosSliderEvent-' + data.sliderNumber);
 		    	$(document).unbind('.iosSliderEvent-' + data.sliderNumber);
 		    	$(document).unbind('keydown.iosSliderEvent');
+		    	$(window).unbind('.iosSliderEvent');
 		    	$(this).unbind('.iosSliderEvent');
 	    		$(this).children(':first-child').unbind('.iosSliderEvent');
 	    		$(this).children(':first-child').children().unbind('.iosSliderEvent');
@@ -2256,7 +2257,7 @@
 					clearTimeout(scrollTimeouts[i]);
 				}
 	    		
-	    		$this.removeData('iosslider');
+	    		$this.removeData( ['iosslider', 'args'] );
 		    	
 			});
 		


### PR DESCRIPTION
- Fixes issue #178 by unbinding '.iosSliderEvent' events from the window object when destroy() method is called
- Removed 'args' data from slider element when destroy() method is called
