### PR TITLE
Solve Issue #218 (IE8 with direction RTL for arabic languages)

### DIFF
--- a/_src/jquery.iosslider.js
+++ b/_src/jquery.iosslider.js
@@ -1296,7 +1296,7 @@
 					sliderMin[sliderNumber] = sliderMax[sliderNumber] + centeredSlideOffset;
 
 					$(scrollerNode).css({
-						position: 'relative',
+						position: !isIe8 ? 'relative' : 'absolute',
 						cursor: grabOutCursor,
 						'webkitPerspective': '0',
 						'webkitBackfaceVisibility': 'hidden',


### PR DESCRIPTION
Hello,

I commit a solution for IE8 problem with RTL.

For some reason, IE8 don't work fine with layer "slider" when this has position: relative.
When is a IE8, I set position to absolute instead of relative.
