### PR TITLE
targetSlideNumber and targetSlideObject added to onSlideStart args

### DIFF
--- a/_src/jquery.iosslider.js
+++ b/_src/jquery.iosslider.js
@@ -944,8 +944,6 @@
 				this.targetSlideNumber = undefined;
 				this.targetSlideObject = undefined;
 			} else if(func == 'start') {
-				this.targetSlideNumber = undefined;
-				this.targetSlideObject = undefined;
 			} else if(func == 'change') {
 				this.slideChanged = true;
 				this.prevSlideNumber = ($(node).parent().data('args') == undefined) ? settings.startAtSlide : $(node).parent().data('args').currentSlideNumber;


### PR DESCRIPTION
targetSlideNumber and targetSlideObject should be available for the onSlideStart handler.
