### PR TITLE
Update jquery.iosslider.js

### DIFF
--- a/_src/jquery.iosslider.js
+++ b/_src/jquery.iosslider.js
@@ -1120,7 +1120,7 @@
 				var data = $this.data('iosslider');	
 				if(data != undefined) return true;
            		
-           		$(this).find('img').bind('dragstart.iosSliderEvent', function(event) { event.preventDefault(); });
+           		$(this).delegate('img', 'dragstart.iosSliderEvent', function(event) { event.preventDefault(); });
 
 				if(settings.infiniteSlider) {
 					settings.scrollbar = false;


### PR DESCRIPTION
Replace bind with delegate to fix bug where dynamic image inserts (E.g. picturefill.js) cause desktopClickDrag errors.
