### PR TITLE
Fix crash when slider is not visible

### DIFF
--- a/_src/jquery.iosslider.js
+++ b/_src/jquery.iosslider.js
@@ -982,7 +982,7 @@
 		
 		autoSlide: function(scrollerNode, slideNodes, scrollTimeouts, scrollbarClass, scrollbarWidth, stageWidth, scrollbarStageWidth, scrollMargin, scrollBorder, originalOffsets, childrenOffsets, slideNodeOuterWidths, sliderNumber, infiniteSliderWidth, numberOfSlides, centeredSlideOffset, settings) {
 			
-			if(!iosSliderSettings[sliderNumber].autoSlide) return false;
+			if(!iosSliderSettings[sliderNumber].autoSlide || stageWidth < 1 || numberOfSlides < 1) return false;
 			
 			helpers.autoSlidePause(sliderNumber);
 


### PR DESCRIPTION
Fixes #338, this prevents the infinite loop to occur and doesn't affect the autoplay once the slider is visible again, code is tested and working